### PR TITLE
[BUGFIX] Provide fallback focus element to focus-trapper

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -13,6 +13,7 @@ export default Component.extend({
 
     this.focusTrap = createFocusTrap(this.element, {
       clickOutsideDeactivates: true,
+      fallbackFocus: `#${this.elementId}`,
 
       onDeactivate: () => {
         this.modal.close();


### PR DESCRIPTION
When opening a modal without "tabbable element", focus trapper raised an error.
It's now fixed thanks to the `fallbackFocus` attribute. 
The fallback element will be the auto-generated wrapper around each `modal` component.

See https://github.com/davidtheclark/focus-trap#usage