### PR TITLE
Remove obsolete `ember-cli-htmlbars-inline-precompile` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.15.2",
     "ember-cli-dependency-checker": "^3.1.0",
-    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",


### PR DESCRIPTION
`ember-cli-htmlbars` takes care of this now