### PR TITLE
Convert `ember-animated` to a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Compatibility
 
 * Ember.js v3.4 or above
 * Ember CLI v2.13 or above
+* ember-animated v0.8
 * Node.js v10, v12, v14 or above
 
 
@@ -16,6 +17,7 @@ Installation
 ------------------------------------------------------------------------------
 
 ```
+ember install ember-animated
 ember install ember-promise-modals
 ```
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-animated": "^0.8.0",
     "ember-auto-import": "^1.5.3",
     "ember-cli-babel": "^7.19.0",
     "ember-cli-htmlbars": "^4.3.1",
@@ -30,6 +29,7 @@
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-animated": "^0.8.0",
     "ember-cli": "~3.17.0",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-inject-live-reload": "^2.0.2",
@@ -55,6 +55,9 @@
     "loader.js": "^4.7.0",
     "prettier": "^1.19.1",
     "qunit-dom": "^1.2.0"
+  },
+  "peerDependencies": {
+    "ember-animated": "^0.8.0"
   },
   "engines": {
     "node": "10.* || 12.* || >= 14.*"


### PR DESCRIPTION
That way it's easier to support multiple versions of `ember-animated` in parallel, since the host app version will automatically be used, without causing issues with `ember-cli-dependency-lint`.