### PR TITLE
Expose `clickOutsideDeactivates` on the `modals` service

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 import createFocusTrap from 'focus-trap';
 
@@ -8,11 +9,15 @@ export default Component.extend({
   layout,
   classNames: ['epm-modal'],
 
+  modals: service(),
+
   didInsertElement() {
     this._super(...arguments);
 
+    let { clickOutsideDeactivates } = this.modals;
+
     this.focusTrap = createFocusTrap(this.element, {
-      clickOutsideDeactivates: true,
+      clickOutsideDeactivates,
 
       onDeactivate: () => {
         this.modal.close();

--- a/addon/services/modals.js
+++ b/addon/services/modals.js
@@ -12,6 +12,8 @@ export default Service.extend({
   count: alias('_stack.length'),
   top: alias('_stack.lastObject'),
 
+  clickOutsideDeactivates: true,
+
   backdropDuration: 600,
   backdropTransition: fade,
 

--- a/tests/application/basics-test.js
+++ b/tests/application/basics-test.js
@@ -23,6 +23,24 @@ module('Application | basics', function (hooks) {
     assert.dom('.epm-modal').doesNotExist();
   });
 
+  test('clicking the backdrop does not close the modal if `clickOutsideDeactivates` is `false`', async function (assert) {
+    this.owner.lookup('service:modals').clickOutsideDeactivates = false;
+
+    await visit('/');
+    assert.dom('.epm-backdrop').doesNotExist();
+    assert.dom('.epm-modal').doesNotExist();
+
+    await click('[data-test-show-modal]');
+    await animationsSettled();
+    assert.dom('.epm-backdrop').exists();
+    assert.dom('.epm-modal').exists();
+
+    await click('.epm-backdrop');
+    await animationsSettled();
+    assert.dom('.epm-backdrop').exists();
+    assert.dom('.epm-modal').exists();
+  });
+
   test('opening a modal disables scrolling on the <body> element', async function (assert) {
     await visit('/');
     assert.dom('body', document).hasStyle({ overflow: 'visible' });


### PR DESCRIPTION
This can be used to deactivate the click-outside-closes-modal behavior that is currently enabled by default