### PR TITLE
Add `qunit-console-grouper` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "loader.js": "^4.7.0",
     "prettier": "^2.0.5",
+    "qunit-console-grouper": "^0.2.0",
     "qunit-dom": "^1.2.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9071,6 +9071,13 @@ quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
+qunit-console-grouper@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/qunit-console-grouper/-/qunit-console-grouper-0.2.0.tgz#41ff6991b28dd53e1c76d83d75700afa5534d550"
+  integrity sha512-HPoUlD3AKFSuucAt1GsZCcrG+u0c3fw/1/L5QhZZfmwBshXnK8ejlfwMGKFOiNV8pTpNajccKYxmKvHz8JJIIg==
+  dependencies:
+    broccoli-funnel "^2.0.2"
+
 qunit-dom@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/qunit-dom/-/qunit-dom-1.2.0.tgz#464cca19e9976c4cee4b14b06da6645c03026880"


### PR DESCRIPTION
This makes it significantly easier to debug things using `console.log()` 😉 