### PR TITLE
service/modals: Reset `.epm-scrolling-disabled` class in the destructor

### DIFF
--- a/addon/services/modals.js
+++ b/addon/services/modals.js
@@ -37,6 +37,10 @@ export default Service.extend({
     this._stack = A([]);
   },
 
+  willDestroy() {
+    this._onLastModalRemoved();
+  },
+
   open(name, data) {
     let modal = new Modal(this, name, data);
     this._stack.pushObject(modal);


### PR DESCRIPTION
When running the test suite and a test is not closing the modal at the end then the `.epm-scrolling-disabled` CSS class will not be reset properly. This PR fixes the issue by ensuring that the class is always removed in the destructor.