### PR TITLE
Replace custom implementation with set-body-class

### DIFF
--- a/addon/modal.js
+++ b/addon/modal.js
@@ -18,10 +18,6 @@ export default class Modal {
 
     this._service._stack.removeObject(this);
     this._deferred.resolve(result);
-
-    if (this._service._stack.length === 0) {
-      this._service._onLastModalRemoved();
-    }
   }
 
   then(onFulfilled, onRejected) {

--- a/addon/services/modals.js
+++ b/addon/services/modals.js
@@ -39,26 +39,10 @@ export default Service.extend({
     this._stack = A([]);
   },
 
-  willDestroy() {
-    this._onLastModalRemoved();
-  },
-
   open(name, data) {
     let modal = new Modal(this, name, data);
     this._stack.pushObject(modal);
 
-    if (this._stack.length === 1) {
-      this._onFirstModalAdded();
-    }
-
     return modal;
-  },
-
-  _onFirstModalAdded() {
-    document.body.classList.add('epm-scrolling-disabled');
-  },
-
-  _onLastModalRemoved() {
-    document.body.classList.remove('epm-scrolling-disabled');
   },
 });

--- a/addon/templates/components/modal-container.hbs
+++ b/addon/templates/components/modal-container.hbs
@@ -1,3 +1,7 @@
+{{#if this.modals._stack.length}}
+  {{set-body-class "epm-scrolling-disabled"}}
+{{/if}}
+
 {{#animated-if
   this.modals.count
   use=this.modals.backdropTransition

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ember-auto-import": "^1.6.0",
     "ember-cli-babel": "^7.23.0",
     "ember-cli-htmlbars": "^5.3.1",
+    "ember-set-body-class": "^1.0.1",
     "focus-trap": "^5.1.0"
   },
   "devDependencies": {

--- a/tests/application/basics-test.js
+++ b/tests/application/basics-test.js
@@ -43,14 +43,17 @@ module('Application | basics', function (hooks) {
 
   test('opening a modal disables scrolling on the <body> element', async function (assert) {
     await visit('/');
+    assert.dom('body', document).doesNotHaveClass('epm-scrolling-disabled');
     assert.dom('body', document).hasStyle({ overflow: 'visible' });
 
     await click('[data-test-show-modal]');
     await animationsSettled();
+    assert.dom('body', document).hasClass('epm-scrolling-disabled');
     assert.dom('body', document).hasStyle({ overflow: 'hidden' });
 
     await click('.epm-backdrop');
     await animationsSettled();
+    assert.dom('body', document).doesNotHaveClass('epm-scrolling-disabled');
     assert.dom('body', document).hasStyle({ overflow: 'visible' });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5175,6 +5175,13 @@ ember-router-generator@^2.0.0:
     "@babel/traverse" "^7.4.5"
     recast "^0.18.1"
 
+ember-set-body-class@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ember-set-body-class/-/ember-set-body-class-1.0.1.tgz#94c0126a5fdb1e780e6568f41c443b0c657f5724"
+  integrity sha512-W4y36lozFstvrv1XERCghgQx8s7RuyJbnPhM+9PTrdwwLpSEQYLEdeASHgeCLqb6Bz7AQeIbyf++2b7u5jPfTw==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+
 ember-source-channel-url@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-source-channel-url/-/ember-source-channel-url-1.2.0.tgz#77eb9d0889e5f5370e6c70fcb2696c63ff4a34a1"


### PR DESCRIPTION
Removes the necessity to reach for a private method call from the modal class, now that the set-body-class addon reached a stable release.