### PR TITLE
Expose focus-trap configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,24 @@ EPM will ensure to [focus the first "tabbable element" by default](https://www.w
 If no focusable element is present, focus will be applied on the currently
 visible modal amber-auto-generated container.
 
+The `modals` service can be extended in your applications to modify focus-trap options on the fly. The most important `clickOutsideDeactivates` option is exposed as a separate property on the service. Setting `focusTrapOptions` on the service will override the `clickOutsideDeactivates` property.
+
+```js
+import ModalServices from 'ember-promise-modals/services/modals';
+
+export default ModalServices.extend({
+  clickOutsideDeactivates: false, // defaults to true for EPM
+
+  // or, overriding the above
+
+  focusTrapOptions: {
+    clickOutsideDeactivates: false, // defaults to false in focus-trap. true is recommended
+    preventScroll: true, 
+    // see more options at https://github.com/focus-trap/focus-trap#createfocustrapelement-createoptions
+  },
+});
+```
+
 
 Contributing
 ------------------------------------------------------------------------------

--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -14,15 +14,21 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    let { clickOutsideDeactivates } = this.modals;
+    let { focusTrapOptions: options, clickOutsideDeactivates } = this.modals;
 
-    this.focusTrap = createFocusTrap(this.element, {
-      clickOutsideDeactivates,
-
-      onDeactivate: () => {
-        this.modal.close();
+    options = Object.assign(
+      {},
+      options || {
+        clickOutsideDeactivates,
       },
-    });
+      {
+        onDeactivate: () => {
+          this.modal.close();
+        },
+      },
+    );
+
+    this.focusTrap = createFocusTrap(this.element, options);
 
     this.focusTrap.activate();
   },

--- a/addon/services/modals.js
+++ b/addon/services/modals.js
@@ -12,6 +12,7 @@ export default Service.extend({
   count: alias('_stack.length'),
   top: alias('_stack.lastObject'),
 
+  focusTrapOptions: undefined,
   clickOutsideDeactivates: true,
 
   backdropDuration: 600,

--- a/tests/application/basics-test.js
+++ b/tests/application/basics-test.js
@@ -41,6 +41,26 @@ module('Application | basics', function (hooks) {
     assert.dom('.epm-modal').exists();
   });
 
+  test('clicking the backdrop does not close the modal if `clickOutsideDeactivates` is `false` using the focusTrap options', async function (assert) {
+    this.owner.lookup('service:modals').focusTrapOptions = {
+      clickOutsideDeactivates: false,
+    };
+
+    await visit('/');
+    assert.dom('.epm-backdrop').doesNotExist();
+    assert.dom('.epm-modal').doesNotExist();
+
+    await click('[data-test-show-modal]');
+    await animationsSettled();
+    assert.dom('.epm-backdrop').exists();
+    assert.dom('.epm-modal').exists();
+
+    await click('.epm-backdrop');
+    await animationsSettled();
+    assert.dom('.epm-backdrop').exists();
+    assert.dom('.epm-modal').exists();
+  });
+
   test('opening a modal disables scrolling on the <body> element', async function (assert) {
     await visit('/');
     assert.dom('body', document).hasStyle({ overflow: 'visible' });


### PR DESCRIPTION
This is an extension to #178 released with 0.2.1 and enables more fine grained control over the focus-trap, which might be necessary to work around issues with clickOutsideDeactivates vs allowOutsideClick described in [the projects README](https://github.com/focus-trap/focus-trap#createfocustrapelement-createoptions).