### PR TITLE
fix backdrop not animating immediately after the last modal is closed

### DIFF
--- a/addon/modal.js
+++ b/addon/modal.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line ember/no-computed-properties-in-native-classes
+import { computed, set } from '@ember/object';
 import { waitForPromise } from '@ember/test-waiters';
 
 import { defer } from 'rsvp';
@@ -18,6 +20,11 @@ export default class Modal {
     return this._result;
   }
 
+  @computed('_deferredOutAnimation')
+  get isClosing() {
+    return Boolean(this._deferredOutAnimation);
+  }
+
   close(result) {
     if (this._componentInstance) {
       this._componentInstance.closeModal(result);
@@ -30,7 +37,7 @@ export default class Modal {
 
   _resolve(result) {
     if (!this._deferredOutAnimation) {
-      this._deferredOutAnimation = defer();
+      set(this, '_deferredOutAnimation', defer());
 
       this._result = result;
       this._deferred.resolve(result);

--- a/addon/services/modals.js
+++ b/addon/services/modals.js
@@ -1,12 +1,14 @@
 import { A } from '@ember/array';
-import { set } from '@ember/object';
+import { computed, set } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import Service from '@ember/service';
 
 import Modal from '../modal';
 
 export default Service.extend({
-  count: alias('_stack.length'),
+  count: computed('_stack.@each.isClosing', function () {
+    return this._stack.filter(modal => !modal.isClosing).length;
+  }),
   top: alias('_stack.lastObject'),
 
   clickOutsideDeactivates: true,

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -11,6 +11,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~3.4.0',
+            'ember-decorators-polyfill': '^1.1.5',
           },
         },
       },
@@ -19,6 +20,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~3.8.0',
+            'ember-decorators-polyfill': '^1.1.5',
           },
         },
       },

--- a/tests/unit/services/modals-test.js
+++ b/tests/unit/services/modals-test.js
@@ -57,4 +57,19 @@ module('Service | modals', function (hooks) {
 
     modal._remove();
   });
+
+  test('modals do not show up in openCount when closing', async function (assert) {
+    let modals = this.owner.lookup('service:modals');
+    let modal = modals.open('modal');
+
+    assert.equal(modals.count, 1);
+
+    modal._resolve();
+
+    assert.equal(modals.count, 0);
+
+    modal._remove();
+
+    assert.equal(modals.count, 0);
+  });
 });


### PR DESCRIPTION
We had a small regression where the backdrop would only start animating out until after the last modal was done animating out itself. This is not the wanted/expected behavior. It should start it's animation at the same time as the modal.