### PR TITLE
add optional onAnimationModalOutEnd hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ this.modals.open(
     //           You most likely do not have to do this unless you absolutely 
     //           can't have an animation ending in '-out'
     animationKeyframesOutName: 'custom-animation-name-out',
+    // optional: a hook that is called when the closing animation of
+    //           the modal (so not the backdrop) has finished.
+    onAnimationModalOutEnd: () => {}
   },
 );
 ```

--- a/addon/modal.js
+++ b/addon/modal.js
@@ -38,6 +38,9 @@ export default class Modal {
   _resolve(result) {
     if (!this._deferredOutAnimation) {
       set(this, '_deferredOutAnimation', defer());
+      if (this._options.onAnimationModalOutEnd) {
+        this._deferredOutAnimation.promise.then(() => this._options.onAnimationModalOutEnd()).catch(() => {});
+      }
 
       this._result = result;
       this._deferred.resolve(result);

--- a/tests/unit/services/modals-test.js
+++ b/tests/unit/services/modals-test.js
@@ -72,4 +72,31 @@ module('Service | modals', function (hooks) {
 
     assert.equal(modals.count, 0);
   });
+
+  test('modals will call the optional onAnimationModalOutEnd hook when it is passed as an option', async function (assert) {
+    let modals = this.owner.lookup('service:modals');
+    let modal = modals.open(
+      'modal',
+      {},
+      {
+        onAnimationModalOutEnd: () => {
+          assert.step('animation ended');
+        },
+      },
+    );
+    assert.step('modal open');
+
+    modal._resolve();
+    assert.step('modal closing');
+
+    modal._remove();
+    assert.step('modal closed');
+
+    // we need to wait a tick for the closing animation promise to be resolved
+    await new Promise(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    assert.verifySteps(['modal open', 'modal closing', 'modal closed', 'animation ended']);
+  });
 });


### PR DESCRIPTION
This hook is called when the modal finishes its closing animation. Can be used to for example clean up CSS variable overrides.