### PR TITLE
Update production build path for GitHub pages

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -44,7 +44,8 @@ module.exports = function (environment) {
   }
 
   if (environment === 'production') {
-    // here you can enable a production-specific feature
+    // Update root URL for GitHub pages
+    ENV.rootURL = '/ember-promise-modals/';
   }
 
   return ENV;


### PR DESCRIPTION
The GitHub page is in a subfolder and the `index.html` targets root otherwise.