### PR TITLE
Specify octane edition in package.json & add missing optional features

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
   "engines": {
     "node": "12.* || >= 14.*"
   },
+  "ember": {
+    "edition": "octane"
+  },
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,4 +1,6 @@
 {
   "application-template-wrapper": false,
-  "jquery-integration": false
+  "default-async-observers": true,
+  "jquery-integration": false,
+  "template-only-glimmer-components": true
 }


### PR DESCRIPTION
This was throwing in CI. Apparently it's required now. Generated through `npx @ember/octanify`