### PR TITLE
Legacy: Downgrade native class to Ember.Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The better way to handle modals in your Ember.js apps.
 
 ## Compatibility
 
-- Ember.js v3.4 or above
+- Ember.js v2.18 or above
 - Ember CLI v2.13 or above
 - Node.js v12, v14 or above
 

--- a/addon/services/modals.js
+++ b/addon/services/modals.js
@@ -30,7 +30,7 @@ export default Service.extend({
    * @returns {Modal}
    */
   open(name, data, options) {
-    let modal = new Modal(this, name, data, options);
+    let modal = Modal.create({ service: this, name, data, options });
 
     this._stack.pushObject(modal);
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,11 +7,18 @@ module.exports = async function () {
     usePnpm: true,
     scenarios: [
       {
+        name: 'ember-lts-2.18',
+        npm: {
+          devDependencies: {
+            'ember-source': '~2.18.0',
+          },
+        },
+      },
+      {
         name: 'ember-lts-3.4',
         npm: {
           devDependencies: {
             'ember-source': '~3.4.0',
-            'ember-decorators-polyfill': '^1.1.5',
           },
         },
       },
@@ -20,7 +27,6 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~3.8.0',
-            'ember-decorators-polyfill': '^1.1.5',
           },
         },
       },


### PR DESCRIPTION
This should allow us to support Ember versions down to Ember 2.18, providing a good path forward for very old apps as a final change to the 2.0 release cycle of this addon.