### PR TITLE
Enhance focus trap configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,17 +226,63 @@ EPM will ensure to [focus the first "tabbable element" by default](https://www.w
 If no focusable element is present, focus will be applied on the currently
 visible auto-generated container for the current modal.
 
-To disable focus trap completely, override the default `Modals` service by
-extending it, place it to `app/services/modals.js`, then create a property
-called `disableFocusTrap` set to `true`:
+Focus Trap can be configured both on the `modals` service, and the individual
+modal level when calling `this.modals.open()`. Global and local options are used
+in that order, which means that local config take precedence.
+
+To set global Focus Trap config that all modals inherit, override the default
+`Modals` service by extending it, place it to `app/services/modals.js`, then
+use the `focusTrapOptions` property:
 
 ```js
 import BaseModalsService from 'ember-promise-modals/services/modals';
 
 export default class ModalsService extends BaseModalsService {
-  disableFocusTrap = true;
+  focusTrapOptions = {
+    clickOutsideDeactivates: false,
+  };
 }
 ```
+
+Example for local Focus Trap option, when opening a specific modal:
+
+```js
+this.modals.open(
+  'file-preview',
+  { fileUrl: this.fileUrl },
+  {
+    focusTrapOptions: {
+      clickOutsideDeactivates: false,
+    },
+  },
+);
+```
+
+To disable Focus Trap completely, set `focusTrapOptions` to `null` on the
+`modals` service:
+
+```js
+import BaseModalsService from 'ember-promise-modals/services/modals';
+
+export default class ModalsService extends BaseModalsService {
+  focusTrapOptions = null;
+}
+```
+
+Or when opening a modal:
+
+```js
+this.modals.open(
+  'file-preview',
+  { fileUrl: this.fileUrl },
+  {
+    focusTrapOptions: null,
+  },
+);
+```
+
+⚠️ _We strongly advise against doing this. This will in most cases worsen the
+accessibility of modals for your users. Be very careful._
 
 ## Testing
 

--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -19,32 +19,42 @@ export default Component.extend({
   optionsClassName: readOnly('modal._options.className'),
 
   modalElementId: null,
+  focusTrapOptions: null,
 
   init() {
     this._super(...arguments);
 
     set(this, 'modalElementId', guidFor(this));
     this.modal._componentInstance = this;
+
+    let { focusTrapOptions: globalFocusTrapOptions } = this.modals;
+    let { focusTrapOptions: localFocusTrapOptions } = this.modal._options;
+
+    if (localFocusTrapOptions !== null) {
+      this.focusTrapOptions = localFocusTrapOptions || globalFocusTrapOptions;
+    }
   },
 
   didInsertElement() {
     this._super(...arguments);
 
-    let { clickOutsideDeactivates, disableFocusTrap } = this.modals;
     let element = document.getElementById(this.modalElementId);
-    let options = {
-      clickOutsideDeactivates,
-      fallbackFocus: `#${this.modalElementId}`,
-      onDeactivate: () => {
-        if (this.isDestroyed || this.isDestroying) {
-          return;
-        }
 
-        this.closeModal();
-      },
-    };
+    if (this.focusTrapOptions) {
+      let options = {
+        ...this.focusTrapOptions,
+        fallbackFocus: `#${this.modalElementId}`,
+        onDeactivate: () => {
+          this.focusTrapOptions.onDeactivate?.();
 
-    if (!disableFocusTrap) {
+          if (this.isDestroyed || this.isDestroying) {
+            return;
+          }
+
+          this.closeModal();
+        },
+      };
+
       this.focusTrap = createFocusTrap(element, options);
       this.focusTrap.activate();
     }
@@ -90,7 +100,9 @@ export default Component.extend({
     set(this, 'animatingOutClass', this.outAnimationClass);
 
     if (this.focusTrap) {
-      this.focusTrap.deactivate({ onDeactivate: null });
+      this.focusTrap.deactivate({
+        onDeactivate: this.focusTrapOptions.onDeactivate,
+      });
     }
 
     this.modal._resolve(result);

--- a/addon/services/modals.js
+++ b/addon/services/modals.js
@@ -1,4 +1,5 @@
 import { A } from '@ember/array';
+import { deprecate } from '@ember/debug';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import Service from '@ember/service';
@@ -11,12 +12,34 @@ export default Service.extend({
   }),
   top: alias('_stack.lastObject'),
 
-  clickOutsideDeactivates: true,
-  disableFocusTrap: false,
+  focusTrapOptions: undefined,
+  clickOutsideDeactivates: undefined,
 
   init() {
     this._super(...arguments);
     this._stack = A([]);
+
+    deprecate(
+      'Defining `clickOutsideDeactivates` directly on the `modals` service is deprecated. ' +
+        `Please use \`focusTrapOptions: { clickOutsideDeactivates: ${this.clickOutsideDeactivates} }\` instead.`,
+      typeof this.clickOutsideDeactivates === 'undefined',
+      {
+        id: 'ember-promise-modals.clickOutsideDeactivates-on-modals-service',
+        since: '2.1.0',
+        until: '3.0.0',
+        for: 'ember-promise-modals',
+      },
+    );
+
+    if (this.focusTrapOptions !== null) {
+      let focusTrapOptions = this.focusTrapOptions ?? {};
+      let clickOutsideDeactivates = focusTrapOptions.clickOutsideDeactivates ?? this.clickOutsideDeactivates ?? true;
+
+      this.focusTrapOptions = {
+        ...this.focusTrapOptions,
+        clickOutsideDeactivates,
+      };
+    }
   },
 
   willDestroy() {

--- a/tests/application/basics-test.js
+++ b/tests/application/basics-test.js
@@ -2,6 +2,7 @@ import { visit, click, triggerKeyEvent, waitUntil } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+import ModalsService from 'ember-promise-modals/services/modals';
 import { setupPromiseModals } from 'ember-promise-modals/test-support';
 
 module('Application | basics', function (hooks) {
@@ -36,8 +37,33 @@ module('Application | basics', function (hooks) {
     assert.dom('.epm-modal').doesNotExist();
   });
 
+  test('DEPRECATED: clicking the backdrop does not close the modal if `clickOutsideDeactivates` is `false`', async function (assert) {
+    this.owner.unregister('service:modals');
+    this.owner.register(
+      'service:modals',
+      ModalsService.extend({
+        clickOutsideDeactivates: false,
+      }),
+    );
+
+    await visit('/');
+
+    assert.dom('.epm-backdrop').doesNotExist();
+    assert.dom('.epm-modal').doesNotExist();
+
+    await click('[data-test-show-modal]');
+
+    assert.dom('.epm-backdrop').exists();
+    assert.dom('.epm-modal').exists();
+
+    await click('.epm-backdrop');
+
+    assert.dom('.epm-backdrop').exists();
+    assert.dom('.epm-modal').exists();
+  });
+
   test('clicking the backdrop does not close the modal if `clickOutsideDeactivates` is `false`', async function (assert) {
-    this.owner.lookup('service:modals').clickOutsideDeactivates = false;
+    this.owner.lookup('service:modals').focusTrapOptions.clickOutsideDeactivates = false;
 
     await visit('/');
 

--- a/tests/integration/configuration/focus-trap-test.js
+++ b/tests/integration/configuration/focus-trap-test.js
@@ -1,4 +1,4 @@
-import { render, settled } from '@ember/test-helpers';
+import { click, render, settled, triggerKeyEvent } from '@ember/test-helpers';
 import focus from '@ember/test-helpers/dom/focus';
 import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
@@ -7,22 +7,30 @@ import Component from '@ember/component';
 
 import hbs from 'htmlbars-inline-precompile';
 
+import ModalsService from 'ember-promise-modals/services/modals';
 import { setupPromiseModals } from 'ember-promise-modals/test-support';
 
 module('Configuration | focus trap', function (hooks) {
   setupRenderingTest(hooks);
   setupPromiseModals(hooks);
 
-  let renderAndOpenModal = async context => {
+  let renderAndOpenModal = async (context, modalOptions) => {
     await render(hbs`
       <button type="button" data-test-outside-button>👋</button>
       <EpmModalContainer />
     `);
 
     let modals = context.owner.lookup('service:modals');
-    modals.open('foo');
+    modals.open('foo', undefined, modalOptions);
 
     await settled();
+  };
+
+  // Since `setupPromiseModals(hooks)` perform a lookup at `beforeEach`, use
+  // this to get a freshly baked service
+  let reregisterModalsService = (owner, obj) => {
+    owner.unregister('service:modals');
+    owner.register('service:modals', obj);
   };
 
   hooks.beforeEach(function () {
@@ -30,7 +38,11 @@ module('Configuration | focus trap', function (hooks) {
       'component:foo',
       Component.extend({
         tagName: '',
-        layout: hbs`<button type="button" data-test-inside-button>🎉</button>`,
+        layout: hbs`
+          <button type="button" data-test-inside-button onclick={{action this.close}}>
+            🎉
+          </button>
+        `,
       }),
     );
   });
@@ -45,8 +57,12 @@ module('Configuration | focus trap', function (hooks) {
   });
 
   test('focus trap is disabled', async function (assert) {
-    let modals = this.owner.lookup('service:modals');
-    modals.set('disableFocusTrap', true);
+    reregisterModalsService(
+      this.owner,
+      ModalsService.extend({
+        focusTrapOptions: null,
+      }),
+    );
 
     await renderAndOpenModal(this);
 
@@ -54,5 +70,136 @@ module('Configuration | focus trap', function (hooks) {
 
     assert.dom('[data-test-outside-button]').isFocused();
     assert.dom('[data-test-inside-button]').isNotFocused();
+  });
+
+  test('global focus trap options', async function (assert) {
+    reregisterModalsService(
+      this.owner,
+      ModalsService.extend({
+        // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
+        focusTrapOptions: {
+          onActivate() {
+            assert.step('onActivate was called');
+          },
+        },
+      }),
+    );
+
+    await renderAndOpenModal(this);
+
+    assert.verifySteps(['onActivate was called']);
+  });
+
+  test('local focus trap options', async function (assert) {
+    await renderAndOpenModal(this, {
+      focusTrapOptions: {
+        onActivate() {
+          assert.step('onActivate was called');
+        },
+      },
+    });
+
+    assert.verifySteps(['onActivate was called']);
+  });
+
+  test('local focus trap options override service options', async function (assert) {
+    assert.expect(2);
+
+    reregisterModalsService(
+      this.owner,
+      ModalsService.extend({
+        // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
+        focusTrapOptions: {
+          onActivate() {
+            assert.step('global onActivate was called');
+          },
+
+          onDeactivate() {
+            assert.notOk(true, 'global onDeactivate should have been overriden');
+          },
+        },
+      }),
+    );
+
+    await renderAndOpenModal(this, {
+      focusTrapOptions: {
+        onActivate() {
+          assert.step('local onActivate was called');
+        },
+      },
+    });
+
+    await click('[data-test-inside-button]');
+
+    assert.verifySteps(['local onActivate was called']);
+  });
+
+  test('focust trap is disabled locally', async function (assert) {
+    assert.expect(0);
+
+    reregisterModalsService(
+      this.owner,
+      ModalsService.extend({
+        // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects
+        focusTrapOptions: {
+          onActivate() {
+            assert.notOk(true, 'global onActivate should not have been called');
+          },
+        },
+      }),
+    );
+
+    await renderAndOpenModal(this, {
+      focusTrapOptions: null,
+    });
+
+    await click('[data-test-inside-button]');
+  });
+
+  test('globally disabled focusTrapOptions is overriden when local options are provided', async function (assert) {
+    reregisterModalsService(
+      this.owner,
+      ModalsService.extend({
+        focusTrapOptions: null,
+      }),
+    );
+
+    await renderAndOpenModal(this, {
+      focusTrapOptions: {
+        onActivate() {
+          assert.step('local onActivate was called');
+        },
+      },
+    });
+
+    assert.verifySteps(['local onActivate was called']);
+  });
+
+  test('onDeactivate is called on when the modal is closed when the Escape key is pressed', async function (assert) {
+    await renderAndOpenModal(this, {
+      focusTrapOptions: {
+        onDeactivate() {
+          assert.step('onDeactivate was called');
+        },
+      },
+    });
+
+    await triggerKeyEvent(document, 'keydown', 'Escape');
+
+    assert.verifySteps(['onDeactivate was called']);
+  });
+
+  test('onDeactivate is called on when the modal is closed when the modal is closed via the close action', async function (assert) {
+    await renderAndOpenModal(this, {
+      focusTrapOptions: {
+        onDeactivate() {
+          assert.step('onDeactivate was called');
+        },
+      },
+    });
+
+    await click('[data-test-inside-button]');
+
+    assert.verifySteps(['onDeactivate was called']);
   });
 });


### PR DESCRIPTION
- Support focus trap options on a per-modal basis
- Move `clickOutsideDeactivates` along with the rest of focus trap options
- Replace `disableFocusTrap` with `focusTrapOptions = null`