### PR TITLE
Ensure calls to @close run before the focus-out deactivation

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -44,8 +44,8 @@ export default Component.extend({
       let options = {
         ...this.focusTrapOptions,
         fallbackFocus: `#${this.modalElementId}`,
-        onDeactivate: () => {
-          this.focusTrapOptions.onDeactivate?.();
+        onPostDeactivate: (...args) => {
+          this.focusTrapOptions.onPostDeactivate?.(...args);
 
           if (this.isDestroyed || this.isDestroying) {
             return;

--- a/tests/application/basics-test.js
+++ b/tests/application/basics-test.js
@@ -108,4 +108,20 @@ module('Application | basics', function (hooks) {
 
     assert.dom('.epm-modal').doesNotExist();
   });
+
+  test('closing the modal via the @close function returns passed values', async function (assert) {
+    await visit('/');
+
+    let applicationController = this.owner.lookup('controller:application');
+
+    assert.strictEqual(applicationController.get('result'), undefined);
+    assert.dom('.epm-modal').doesNotExist();
+
+    await click('[data-test-show-modal]');
+    await click('[data-test-button-close]');
+
+    assert.deepEqual(applicationController.get('result'), {
+      foo: 'bar',
+    });
+  });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -8,7 +8,12 @@ export default Controller.extend({
 
   actions: {
     showModal() {
-      this.modals.open(Modal1);
+      this.modals
+        .open(Modal1)
+        .then(result => {
+          this.result = result;
+        })
+        .catch(() => {});
     },
 
     showModalFromTop() {

--- a/tests/dummy/app/templates/components/modal1.hbs
+++ b/tests/dummy/app/templates/components/modal1.hbs
@@ -1,7 +1,7 @@
 {{!-- template-lint-disable no-action --}}
 <div class="modal modal1">
   <header>
-    <button type="button" {{action @close}}>Close</button>
+    <button type="button" data-test-button-close {{action @close (hash foo="bar")}}>Close</button>
   </header>
 
   <h2>Modal 1</h2>


### PR DESCRIPTION
This wasn't covered by our test suite before.

Expected behavior: Calling `@close` on a modal will close the modal and in turn should resolve the modal promise with any arguments passed to that function. 

Actual behavior: Closing the modal also triggers `focus-out`, which in turn also calls the modal close callback but without any return data, racing the manual call to `@close`, which means the modal promise is resolved with `undefined` because the `onDeactivate` hook of `focus-out` runs before the modal close.

This happens because `focus-out` changed when it's `onDeactivate` hook is triggered, introducing a new `onPostDeactivate` which has the same timing as the old one.