### PR TITLE
Refactor handling of `focusTrap.onDeactivate` method

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -44,8 +44,8 @@ export default Component.extend({
       let options = {
         ...this.focusTrapOptions,
         fallbackFocus: `#${this.modalElementId}`,
-        onPostDeactivate: (...args) => {
-          this.focusTrapOptions.onPostDeactivate?.(...args);
+        onDeactivate: (...args) => {
+          this.focusTrapOptions.onDeactivate?.(...args);
 
           if (this.isDestroyed || this.isDestroying) {
             return;
@@ -99,18 +99,18 @@ export default Component.extend({
     // Trigger out animation
     set(this, 'animatingOutClass', this.outAnimationClass);
 
-    if (this.focusTrap) {
-      this.focusTrap.deactivate({
-        onDeactivate: this.focusTrapOptions.onDeactivate,
-      });
-    }
-
     this.modal._resolve(result);
   },
 
   actions: {
     close(result) {
       this.closeModal(result);
+
+      if (this.focusTrap) {
+        this.focusTrap.deactivate({
+          onDeactivate: this.focusTrapOptions.onDeactivate,
+        });
+      }
     },
   },
 });


### PR DESCRIPTION
Turns out `focus-trap` was not the culprit here, but the fact that we resolved the modal _after_ calling the `deactivate` method on the focus trap.

The changes to the events in the dependency were purely coincidental, but using the newly introduced events happended to fix the issue as well as the `onPostDeactivate` happens to run a tick later than the `onDeactivate` which is enough for the `resolve` to happen.

Re #565