### PR TITLE
Replace retained element reference with a method

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -38,9 +38,8 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    let element = document.getElementById(this.modalElementId);
-
     if (this.focusTrapOptions) {
+      let element = this._getElement();
       let options = {
         ...this.focusTrapOptions,
         fallbackFocus: `#${this.modalElementId}`,
@@ -62,7 +61,7 @@ export default Component.extend({
     this.fadeOutEnd = ({ target, animationName }) => {
       this.modals._onModalAnimationEnd();
 
-      let isntTarget = target !== element;
+      let isntTarget = target !== this._getElement();
       let animationEndsWrong = animationName.substring(animationName.length - 4) !== '-out';
 
       if (isntTarget || animationEndsWrong) {
@@ -73,7 +72,7 @@ export default Component.extend({
     };
 
     this.modals._onModalAnimationStart();
-    element.addEventListener('animationend', this.fadeOutEnd);
+    this._getElement().addEventListener('animationend', this.fadeOutEnd);
     set(this, 'animatingOutClass', '');
   },
 
@@ -83,7 +82,7 @@ export default Component.extend({
     }
 
     if (this.fadeOutEnd) {
-      let element = document.getElementById(this.modalElementId);
+      let element = this._getElement();
 
       if (element) {
         element.removeEventListener('animationend', this.fadeOutEnd);
@@ -93,6 +92,10 @@ export default Component.extend({
     }
 
     this._super(...arguments);
+  },
+
+  _getElement() {
+    return document.getElementById(this.modalElementId);
   },
 
   closeModal(result) {


### PR DESCRIPTION
This is start of a chain of refactorings with the goal to make the modal component and it's various states more comprehensible and easier to change. 

While it _should_ not be an issue, it _may_ happen that a reference to the DOM element that represents the modal gets stuck in memory. Retrieving the element from DOM each time seems to make the garbage collector happier. 

This method could and should be replaced by a regular getter once we shift this addon to native classes.