### PR TITLE
Ensure animations are triggered when `prefer-reduced-animation` is used

### DIFF
--- a/addon/styles/ember-promise-modals.css
+++ b/addon/styles/ember-promise-modals.css
@@ -17,14 +17,14 @@
 
 @media (prefers-reduced-motion: reduce) {
   :root {
-  --epm-animation-backdrop-in-duration: 0s;
-  --epm-animation-backdrop-out-duration: 0s;
-  --epm-animation-modal-in-duration: 0s;
-  --epm-animation-modal-out-duration: 0s;
-  --epm-animation-backdrop-in-delay: 0s;
-  --epm-animation-backdrop-out-delay: 0s;
-  --epm-animation-modal-in-delay: 0s;
-  --epm-animation-modal-out-delay: 0s;
+  --epm-animation-backdrop-in-duration: 0.001s;
+  --epm-animation-backdrop-out-duration: 0.001s;
+  --epm-animation-modal-in-duration: 0.001s;
+  --epm-animation-modal-out-duration: 0.001s;
+  --epm-animation-backdrop-in-delay: 0.001s;
+  --epm-animation-backdrop-out-delay: 0.001s;
+  --epm-animation-modal-in-delay: 0.001s;
+  --epm-animation-modal-out-delay: 0.001s;
   }
 }
 


### PR DESCRIPTION
Reducing to 1ms is nearly instant and ensures all browsers trigger the `animationend` event.

Closes #813